### PR TITLE
Use var due to strict mode support on Meteor 1.6>

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 wrapAsync = Meteor.wrapAsync || Meteor._wrapAsync;
 
 Mongo.Collection.prototype.aggregate = function(pipelines, options) {
-  let coll;
+  var coll;
   if (this.rawCollection) {
     // >= Meteor 1.0.4
     coll = this.rawCollection();


### PR DESCRIPTION
Package loading on earlier versions of Meteor (1.6>) do not support block-scoped declarations; <object>.prototype is pre es6 and the additional line that supports driver v. 3 is backwards compatible, it'll be a simple change that will allow support on older versions.

```
both/finances/finances.method.ts (28, 66): Property 'aggregate' does not exist on type 'Collection<Sale>'.
W20180507-14:12:19.108(-5)? (STDERR) packages/sakulstra_aggregate.js:24
W20180507-14:12:19.110(-5)? (STDERR)   let coll;
W20180507-14:12:19.111(-5)? (STDERR)   ^^^
W20180507-14:12:19.112(-5)? (STDERR) 
W20180507-14:12:19.113(-5)? (STDERR) SyntaxError: Block-scoped declarations (let, const, function, class) not yet supported outside strict mode

```