### PR TITLE
Support new mongo driver v4

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 wrapAsync = Meteor.wrapAsync || Meteor._wrapAsync;
 
 Mongo.Collection.prototype.aggregate = function(pipelines, options) {
-  var coll;
+  let coll;
   if (this.rawCollection) {
     // >= Meteor 1.0.4
     coll = this.rawCollection();
@@ -10,8 +10,13 @@ Mongo.Collection.prototype.aggregate = function(pipelines, options) {
     coll = this._getCollection();
   }
   if (MongoInternals.NpmModules.mongodb.version[0] === '3') {
-    var cursor = wrapAsync(coll.aggregate, coll)(pipelines, options);
+    const cursor = wrapAsync(coll.aggregate, coll)(pipelines, options);
     return wrapAsync(cursor.toArray, cursor)();
   }
+  if (MongoInternals.NpmModules.mongodb.version[0] === '4'){
+    const cursor = coll.aggregate(pipelines, options);
+    return wrapAsync(cursor.toArray, cursor)();
+  }
+
   return wrapAsync(coll.aggregate.bind(coll))(pipelines, options);
 };

--- a/package.js
+++ b/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: 'Proper MongoDB aggregations support for Meteor',
-  version: '1.4.3',
+  version: '1.4.4',
   git: 'https://github.com/sakulstra/meteor-aggregate',
   name: 'sakulstra:aggregate'
 });


### PR DESCRIPTION
Hello!
On Meteor 2.6 we are introducing support for the new node.js mongo driver, v4.x, and the aggregate function doesn't require a callback anymore, only the toArray function does.